### PR TITLE
Fixed test runner

### DIFF
--- a/regression/test.sh
+++ b/regression/test.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env
-
 make TOPFILE=test000
 ./test000.opt >> test000.log
 diff test000.log orig/test000.log


### PR DESCRIPTION
The shebang line didn't contain executable name, hence script was hanging. In previous semester this file didn't use shebang at all.
@danyaberezun 