### PR TITLE
Исправление количества используемых регистров

### DIFF
--- a/src/X86.ml
+++ b/src/X86.ml
@@ -3,8 +3,8 @@
 (* The registers: *)
 let regs = [|"%ebx"; "%ecx"; "%esi"; "%edi"; "%eax"; "%edx"; "%ebp"; "%esp"|]
 
-(* We can not freely operate with all register; only 3 by now *)                    
-let num_of_regs = Array.length regs - 5
+(* We can not freely operate with all register; only 4 by now *)                    
+let num_of_regs = Array.length regs - 4
 
 (* We need to know the word size to calculate offsets correctly *)
 let word_size = 4
@@ -99,10 +99,10 @@ class env =
     method allocate =    
       let x, n =
 	let rec allocate' = function
-	| []                            -> ebx     , 0
-	| (S n)::_                      -> S (n+1) , n+1
-	| (R n)::_ when n < num_of_regs -> R (n+1) , stack_slots
-	| _                             -> S 0     , 1
+	| []                                -> ebx     , 0
+	| (S n)::_                          -> S (n+1) , n+1
+	| (R n)::_ when n + 1 < num_of_regs -> R (n+1) , stack_slots
+	| _                                 -> S 0     , 1
 	in
 	allocate' stack
       in


### PR DESCRIPTION
Не смотря на то, что в комментариях написано, что мы будем использовать в символьном стеке только 3 регистра, и то, что `num_of_regs` равно 3, на практике всё равно использовалось 4 регистра из-за ошибки на 1 в методе `env#allocate`. Видимо и хотелось использовать 4 регистра. Поправил комментарий, функцию `env#allocate` и определение `num_of_regs`.