### PR TITLE
Исправление подсчёта необходимого места на стеке

### DIFF
--- a/src/X86.ml
+++ b/src/X86.ml
@@ -100,8 +100,8 @@ class env =
       let x, n =
 	let rec allocate' = function
 	| []                            -> ebx     , 0
-	| (S n)::_                      -> S (n+1) , n+1
-	| (R n)::_ when n < num_of_regs -> R (n+1) , stack_slots
+	| (S n)::_                      -> S (n+1) , n+2
+	| (R n)::_ when n < num_of_regs -> R (n+1) , 0
 	| _                             -> S 0     , 1
 	in
 	allocate' stack


### PR DESCRIPTION
Из-за (отличной от #33) ошибки на 1 в функции `env#allocate` количество необходимой для символьного стека памяти считается неправильно и приводит к неожиданному поведению.

Исправил ошибку, и заодно безобидное, но не понятно зачем нужное обновление `stack_slots` им же, когда мы только что выделили очередной регистр (хотя логичнее нулём, т.е. объёмом использования стека на текущий момент).